### PR TITLE
Fixed errors handling for python2.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,6 +1,8 @@
 Changelog
 =========
 
+- Fixed errors' handling in python2.
+
 Version 0.7
 -----------
 

--- a/djmail/core.py
+++ b/djmail/core.py
@@ -1,20 +1,23 @@
 # -*- coding: utf-8 -*-
-
-import sys
 import io
+import logging
+import sys
+import traceback
 
 from django.conf import settings
 from django.core.mail import get_connection
 from django.core.paginator import Paginator
 from django.utils import timezone
-import traceback
 
 from . import models
+
 
 PY2 = sys.version_info[0] == 2
 StringIO = io.StringIO
 if PY2:
     StringIO = io.BytesIO
+
+logger = logging.getLogger('djmail')
 
 
 def _chunked_iterate_queryset(queryset, chunk_size=10):
@@ -46,6 +49,7 @@ def _safe_send_message(message_model, connection):
             traceback.print_exc(file=f)
             f.seek(0)
             message_model.exception = f.read()
+            logger.error(message_model.exception)
         else:
             if sended == 1:
                 message_model.status = models.STATUS_SENT


### PR DESCRIPTION
Python2:

``` python
import io, traceback

f = io.StringIO()
traceback.print_stack(file=f)


Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/local/Cellar/python/2.7.6_1/Frameworks/Python.framework/Versions/2.7/lib/python2.7/traceback.py", line 269, in print_stack
    print_list(extract_stack(f, limit), file)
  File "/usr/local/Cellar/python/2.7.6_1/Frameworks/Python.framework/Versions/2.7/lib/python2.7/traceback.py", line 23, in print_list
    '  File "%s", line %d, in %s' % (filename,lineno,name))
  File "/usr/local/Cellar/python/2.7.6_1/Frameworks/Python.framework/Versions/2.7/lib/python2.7/traceback.py", line 13, in _print
    file.write(str+terminator)
TypeError: unicode argument expected, got 'str'
```

io.StringIO accepts a unicode string, but python2 traceback module generates 8-bit strings. So solution is BytesIO for Python2.
