### PR TITLE
don't use lambda for default value of uuid

### DIFF
--- a/djmail/models.py
+++ b/djmail/models.py
@@ -25,6 +25,8 @@ STATUS_DISCARDED = 50
 PRIORITY_LOW = 20
 PRIORITY_STANDARD = 50
 
+def new_uuid():
+    return str(uuid.uuid1())
 
 class Message(models.Model):
     STATUS_CHOICES = (
@@ -35,7 +37,7 @@ class Message(models.Model):
     )
 
     uuid = models.CharField(max_length=40, primary_key=True,
-                            default=lambda: str(uuid.uuid1()))
+                            default=new_uuid())
 
     from_email = models.CharField(max_length=1024, blank=True)
     to_email = models.TextField(blank=True)


### PR DESCRIPTION
Seems to break migrations in django 1.7, not sure why..

```
./manage.py makemigrations djmail

...
File "/home/thijs/.virtualenvs/foo/local/lib/python2.7/site-packages/django/db/migrations/writer.py", line 337, in serialize
    raise ValueError("Cannot serialize function: lambda")
ValueError: Cannot serialize function: lambda
```
