### PR TITLE
Declare any non-HTML body as text/plain (e.g. JSON)

### DIFF
--- a/djmail/models.py
+++ b/djmail/models.py
@@ -69,7 +69,7 @@ class Message(models.Model):
         }
 
         # Declare HTML body subtype as text/html else as text/plain
-        key = 'body_' + ('html' if email_message.content_subtype == 'text/html' else 'text')
+        key = 'body_' + ('html' if email_message.content_subtype == 'html' else 'text')
         kwargs[key] = force_text(email_message.body)
 
         # Try to retrieve the HTML body from the alternatives

--- a/djmail/models.py
+++ b/djmail/models.py
@@ -66,11 +66,11 @@ class Message(models.Model):
             return 'body_' + ('html' if the_type.split('/')[-1] == 'html' else 'text')
 
         kwargs = {
-            "from_email": force_text(email_message.from_email),
-            "to_email": ",".join(force_text(x) for x in email_message.to),
+            'from_email': force_text(email_message.from_email),
+            'to_email': ','.join(force_text(x) for x in email_message.to),
             get_body_key(email_message.content_subtype): force_text(email_message.body),
-            "subject": force_text(email_message.subject),
-            "data": base64.b64encode(pickle.dumps(email_message))
+            'subject': force_text(email_message.subject),
+            'data': base64.b64encode(pickle.dumps(email_message))
         }
 
         # Update the body (if missing) from the alternatives


### PR DESCRIPTION
Body sub-type is not restricted to plain or html.
This implementation converts any non html sub-type to plain.