### PR TITLE
Pass extra kwargs to EmailMultiAlternatives in MagicMailBuilder

### DIFF
--- a/djmail/template_mail.py
+++ b/djmail/template_mail.py
@@ -142,7 +142,7 @@ class MagicMailBuilder(object):
         self._template_mail_cls = template_mail_cls
 
     def __getattr__(self, name):
-        def _dynamic_email_generator(to, context, priority=models.PRIORITY_STANDARD):
+        def _dynamic_email_generator(to, context, priority=models.PRIORITY_STANDARD, **kwargs):
             lang = None
 
             if not isinstance(to, string_types):
@@ -158,7 +158,7 @@ class MagicMailBuilder(object):
                 context["lang"] = lang
 
             template_email = self._template_mail_cls(name=name)
-            email_instance = template_email.make_email_object(to, context)
+            email_instance = template_email.make_email_object(to, context, **kwargs)
             email_instance.priority = priority
             return email_instance
 


### PR DESCRIPTION
Hello,

In TemplateEmail we can pass extra kwargs to EmailMultiAlternatives by extra kwargs to ```send``` or ```make_email_object```. Unfortunately, MagicMailBuilder don't accept it. 
It raises:
```TypeError: _dynamic_email_generator() got an unexpected keyword argument 'from_email'```

To standardize made the corrections code.

Greetings,