### PR TITLE
Add djmaster and dj19 to tests in TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,9 @@ matrix:
       env: DJANGO="Django>=1.4,<1.5"
     - python: "3.3"
       env: DJANGO="https://github.com/django/django/archive/master.tar.gz"
-      
+  allow_failures:
+    - env: DJANGO="https://github.com/django/django/archive/master.tar.gz"
+
 install:
   - travis_retry pip install $DJANGO
   - travis_retry pip install psycopg2==2.6.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,32 +8,35 @@ python:
   - "2.7"
 
 env:
-  - DJANGO="django==1.9.2"
-  - DJANGO="django==1.8.9"
-  - DJANGO="django==1.7.10"
-  - DJANGO="django==1.6.11"
-  - DJANGO="django==1.5.12"
-  - DJANGO="django==1.4.22"
+  - DJANGO="Django>=1.9,<1.10"
+  - DJANGO="Django>=1.8,<1.9"
+  - DJANGO="Django>=1.7,<1.8"
+  - DJANGO="Django>=1.6,<1.7"
+  - DJANGO="Django>=1.5,<1.6"
+  - DJANGO="Django>=1.4,<1.5"
+  - DJANGO="https://github.com/django/django/archive/master.tar.gz"
 
 matrix:
   exclude:
     - python: "3.5"
-      env: DJANGO="django==1.7.10"
+      env: DJANGO="Django>=1.7,<1.8"
     - python: "3.5"
-      env: DJANGO="django==1.6.11"
+      env: DJANGO="Django>=1.6,<1.7"
     - python: "3.5"
-      env: DJANGO="django==1.5.12"
+      env: DJANGO="Django>=1.5,<1.6"
     - python: "3.5"
-      env: DJANGO="django==1.4.22"
+      env: DJANGO="Django>=1.4,<1.5"
 
     - python: "3.4"
-      env: DJANGO="django==1.4.22"
+      env: DJANGO="Django>=1.4,<1.5"
 
     - python: "3.3"
-      env: DJANGO="django==1.9.2"
+      env: DJANGO="Django>=1.9,<1.10"
     - python: "3.3"
-      env: DJANGO="django==1.4.22"
-
+      env: DJANGO="Django>=1.4,<1.5"
+    - python: "3.3"
+      env: DJANGO="https://github.com/django/django/archive/master.tar.gz"
+      
 install:
   - travis_retry pip install $DJANGO
   - travis_retry pip install psycopg2==2.6.1


### PR DESCRIPTION
Hello,

I am suggest:
- add Django 1.9 due official release ( https://docs.djangoproject.com/en/1.9/releases/1.9/ ),
- add Django master with ```allow_failures``` for forward compatibility without misleading during pull requests,
- use range versions pinning for support always newest C versions (A.B.C) od django package.

Greetings,

