### PR TITLE
docs: Fix a few typos

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -13,9 +13,9 @@ Why use djmail? Because it:
 - Sends emails using celery tasks.
 - Can retry sending failed messages (with cron task or celery periodic task).
 - Can assign delivery priority.
-- Has a powerfull class to build emails from templates.
+- Has a powerful class to build emails from templates.
 - Works transparently (works as middleware for native django email backends)
 
-djmail was created by Andrey Antukh (@niwinz) and is maintened by David Barragán (@bameda).
+djmail was created by Andrey Antukh (@niwinz) and is maintained by David Barragán (@bameda).
 
 You can read the full documentation at https://bameda.github.io/djmail/.

--- a/djmail/core.py
+++ b/djmail/core.py
@@ -53,7 +53,7 @@ def _safe_send_message(message_model, connection):
 
         message_model.save()
 
-        # Celery backend renturn an AsyncResult object
+        # Celery backend return an AsyncResult object
         return 1 if sended else 0
 
 

--- a/doc/static/asciidoc.js
+++ b/doc/static/asciidoc.js
@@ -105,7 +105,7 @@ toc: function (toclevels) {
  */
 
 footnotes: function () {
-  // Delete existing footnote entries in case we're reloading the footnodes.
+  // Delete existing footnote entries in case we're reloading the footnotes.
   var i;
   var noteholder = document.getElementById("footnotes");
   if (!noteholder) {


### PR DESCRIPTION
There are small typos in:
- README.rst
- djmail/core.py
- doc/static/asciidoc.js

Fixes:
- Should read `return` rather than `renturn`.
- Should read `powerful` rather than `powerfull`.
- Should read `maintained` rather than `maintened`.
- Should read `footnotes` rather than `footnodes`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md